### PR TITLE
Add self-service rate overrides via Datastore and POST /rates API

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -1,0 +1,138 @@
+# Gujrati Tailors — Backend
+
+Spring Boot REST API for a tailor shop's order management, deployed on Google App Engine
+(Standard) with Google Cloud Datastore as the database. This document is a permanent,
+tool-agnostic guide to the project for any developer or AI assistant working in this repo.
+
+## Tech stack
+
+- **Java**: 21
+- **Framework**: Spring Boot 3.3.4 (Web on Jetty, Data REST, Security, Actuator)
+- **Cloud / DB**: Google Cloud Datastore via `spring-cloud-gcp-starter-data-datastore` 5.5.0
+- **Auth**: Stateless JWT (`jjwt` 0.12.3)
+- **Build**: Maven (wrapper `./mvnw`), `appengine-maven-plugin`, google-java-format via `fmt-maven-plugin`
+- **Other**: Lombok, Apache POI (offline Excel export)
+
+## How to run
+
+```bash
+# 1. Start Datastore emulator (separate terminal; uses ./db_data if present)
+./start-datastore-emulator.sh
+
+# 2. Run the app (profile "local" is default in application.yaml)
+source set_vars.sh && mvn spring-boot:run     # serves on :8080
+
+# From IntelliJ: run GujratiTailorsApplication with DATASTORE_EMULATOR_HOST=localhost:8081
+# (see set_vars.sh for the full set of emulator env vars)
+
+# Deploy to Google App Engine (profile "prod")
+./deploy.sh                                    # mvn clean package + appengine:deploy
+```
+
+- Default profile is `local` (Datastore emulator). `prod` profile is set by `app.yaml` on GAE.
+- Prod URL: `https://gujrati-tailors-backend.el.r.appspot.com`
+
+## Package map
+
+```
+com.harvi.tailor
+├── GujratiTailorsApplication       # Spring Boot entry point
+├── GlobalExceptionHandler          # 400 for IllegalArgumentException; 404 ResourceNotFound; else 500
+├── item/                           # Item catalog + self-service rate overrides
+│   ├── Item                        # POJO: id, name, groupName, type, comboItemIds, rate
+│   ├── ItemsGroup                  # record(groupName, List<Item>)
+│   ├── ItemService                 # Hardcoded catalog (structure + default rates) + overlay
+│   ├── ItemController              # GET /items/groupedItems (Cache-Control: no-store)
+│   ├── ItemRate                    # @Entity (kind "itemRate"): id, rate
+│   ├── ItemRateRepository          # DatastoreRepository<ItemRate, String>
+│   ├── RateController              # POST /rates
+│   └── RatesUpdateRequest          # record(Map<String, Integer> rates)
+├── order/                          # Orders
+│   ├── Order                       # @Entity (kind "order") + nested Customer, OrderItem
+│   ├── OrderRepository             # DatastoreRepository (Spring Data REST -> /orders)
+│   ├── OrderService                # Raw Datastore query for filtered search
+│   ├── OrderSearchController       # GET /orders/customSearch
+│   └── OrderRepositoryEventHandler # Before-create: compute/validate order id, set status
+├── security/                       # JWT auth (single hardcoded Admin user)
+├── commons/CommonConfig            # Datastore bean (prod vs local emulator)
+└── utils/                          # ConverterUtils, BackupUtil (offline JSON->Excel)
+```
+
+## Data model & persistence
+
+Datastore kinds:
+
+| Kind | Purpose |
+|------|---------|
+| `order` | Orders (`Customer`, `OrderItem` embedded). Only domain with full CRUD via Spring Data REST. |
+| `itemRate` | **Rate overrides only** — one entity per item id (`@Id` = item id, `rate` int). |
+
+**Not persisted:** item structure (ids, names, groups, combos) and users — hardcoded in Java.
+
+- Project id and namespace: `gujrati-tailors-backend`
+- Composite indexes for order search: `src/main/webapp/WEB-INF/index.yaml`
+- No composite index needed for `itemRate` (`findAll()` only)
+
+### Order id format
+
+`{yyyy-MM-}{C|R}-{orderNumber}` (e.g. `2024-01-R-1119`), computed in `OrderRepositoryEventHandler`.
+
+## REST API
+
+| Method | Path | Notes |
+|--------|------|-------|
+| POST | `/authenticate` | Public. `{username,password}` -> `{jwtToken}` |
+| GET | `/items/groupedItems` | Catalog grouped by category with **effective rates** (defaults + overrides). `Cache-Control: no-store`. |
+| POST | `/rates` | Upsert rate overrides. Body `{ "rates": { "shirt": 400, "pant": 500, ... } }`. Validates known ids, rate 0–9999. |
+| GET/POST/PUT/PATCH/DELETE | `/orders`, `/orders/{id}` | Spring Data REST (HAL/HATEOAS) |
+| GET | `/orders/customSearch` | Filtered search + paging |
+
+All endpoints except `/authenticate` require `Authorization: Bearer <jwt>`.
+CORS is open (`@CrossOrigin` + security `cors`).
+
+Bad rate input returns **HTTP 400** with `{ errorMessage, internalErrorMessage }` (via `GlobalExceptionHandler`).
+
+## Items & rates flow (important)
+
+### Catalog (structure + defaults)
+
+- `ItemService` defines ~25 items in a **static block**: ids, names, groups, combo refs, and **default rates**.
+- Groups (display order): Coat, Shirt-Pant, Kurta-Payjama, Jacket, Miscellaneous.
+- Combos reference component item ids via `comboItemIds`.
+
+### Self-service rate overrides (runtime updates)
+
+**Overlay model** — no migration/seeding required:
+
+1. Hardcoded list = structural source of truth + default rates.
+2. `itemRate` entities in Datastore store **overrides only** (item id -> rate).
+3. `getGroupedItems()` overlays overrides on defaults (`override wins`, else default).
+4. `POST /rates` upserts `ItemRate` rows via `ItemRateRepository.saveAll()`.
+
+```
+GET /items/groupedItems  -> defaults merged with saved overrides
+POST /rates              -> { rates: { itemId: rate, ... } }  (JWT-protected)
+```
+
+**Resilience:** if reading overrides from Datastore fails, `loadRateOverrides()` logs a warning and falls back to hardcoded defaults so order creation never breaks.
+
+**Deployment note:** backend can be deployed before the UI — with no overrides saved, `GET /items/groupedItems` returns the same default rates as before. `POST /rates` is additive.
+
+### Orders vs catalog rates
+
+- **Rates are snapshotted into orders**: each `OrderItem` stores its own `rate` at creation time.
+- The backend does **not** validate order line rates against the catalog.
+- Changing a catalog rate does **not** affect existing orders (historical pricing preserved).
+
+## Security model
+
+- Single hardcoded user `Admin` (BCrypt password in `UserDetailsServiceImpl`).
+- No roles/authorities; any authenticated caller can use all endpoints including `POST /rates`.
+
+## Conventions & gotchas
+
+- Lombok used heavily. `OrderConverterConfig` is dead code (commented out).
+- `spring.main.allow-circular-references: true`.
+- Datastore bean built manually in `CommonConfig` (prod vs emulator).
+- New order search filters likely need a composite index in `index.yaml`.
+- Temporary task notes may exist in `rate-self-service-intent.md` (delete after merge).

--- a/src/main/java/com/harvi/tailor/GlobalExceptionHandler.java
+++ b/src/main/java/com/harvi/tailor/GlobalExceptionHandler.java
@@ -12,6 +12,14 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 @Slf4j
 public class GlobalExceptionHandler {
 
+  @ExceptionHandler({IllegalArgumentException.class})
+  public ResponseEntity<Map<String, String>> handleBadRequest(IllegalArgumentException e) {
+    log.error("Bad request", e);
+    Map<String, String> response =
+        Map.of("errorMessage", e.getMessage(), "internalErrorMessage", e.getMessage());
+    return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+  }
+
   @ExceptionHandler({Exception.class})
   public ResponseEntity<Map<String, String>> handleException(Exception e) {
     log.error("Caught by GlobalExceptionHandler", e);

--- a/src/main/java/com/harvi/tailor/item/Item.java
+++ b/src/main/java/com/harvi/tailor/item/Item.java
@@ -1,11 +1,15 @@
 package com.harvi.tailor.item;
 
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
+@Builder(toBuilder = true)
+@AllArgsConstructor
 @NoArgsConstructor
 @ToString
 @Getter
@@ -14,26 +18,18 @@ public class Item {
 
   private String id;
   private String name;
+  private int rate;
   private String groupName;
   private String type;
   private List<String> comboItemIds;
-  private int rate;
 
-  public Item(
-      String id, String name, int rate, String groupName, String type, List<String> comboItemIds) {
-    this.id = id;
-    this.name = name;
-    this.groupName = groupName;
-    this.rate = rate;
-    this.type = type;
-    this.comboItemIds = comboItemIds;
-  }
-
+  /** Convenience constructor for non-combo items ({@code comboItemIds} is null). */
   public Item(String id, String name, int rate, String groupName, String type) {
     this(id, name, rate, groupName, type, null);
   }
 
   public static class ItemType {
+
     public static final String COAT = "Coat";
     public static final String SHIRT = "Shirt";
     public static final String PANT = "Pant";
@@ -47,6 +43,7 @@ public class Item {
   }
 
   public static class ItemGroup {
+
     public static final String COAT = "Coat";
     public static final String SHIRT_PANT = "Shirt-Pant";
     public static final String KURTA_PAYJAMA = "Kurta-Payjama";

--- a/src/main/java/com/harvi/tailor/item/ItemController.java
+++ b/src/main/java/com/harvi/tailor/item/ItemController.java
@@ -2,6 +2,8 @@ package com.harvi.tailor.item;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,7 +18,10 @@ public class ItemController {
   private final ItemService itemService;
 
   @GetMapping("/groupedItems")
-  public List<ItemsGroup> getGroupedItems() {
-    return itemService.getGroupedItems();
+  public ResponseEntity<List<ItemsGroup>> getGroupedItems() {
+    // Rates can change at runtime, so never let HTTP caches serve a stale catalog.
+    return ResponseEntity.ok()
+        .cacheControl(CacheControl.noStore())
+        .body(itemService.getGroupedItems());
   }
 }

--- a/src/main/java/com/harvi/tailor/item/ItemRate.java
+++ b/src/main/java/com/harvi/tailor/item/ItemRate.java
@@ -1,0 +1,20 @@
+package com.harvi.tailor.item;
+
+import com.google.cloud.spring.data.datastore.core.mapping.Entity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+
+/** A persisted rate override for an item. The {@code id} is the item's id. */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity(name = "itemRate")
+public class ItemRate {
+
+  @Id private String id;
+  private int rate;
+}

--- a/src/main/java/com/harvi/tailor/item/ItemRateRepository.java
+++ b/src/main/java/com/harvi/tailor/item/ItemRateRepository.java
@@ -1,0 +1,5 @@
+package com.harvi.tailor.item;
+
+import com.google.cloud.spring.data.datastore.repository.DatastoreRepository;
+
+public interface ItemRateRepository extends DatastoreRepository<ItemRate, String> {}

--- a/src/main/java/com/harvi/tailor/item/ItemService.java
+++ b/src/main/java/com/harvi/tailor/item/ItemService.java
@@ -4,16 +4,29 @@ import static com.harvi.tailor.item.Item.ItemGroup;
 import static com.harvi.tailor.item.Item.ItemType;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
+@RequiredArgsConstructor
 public class ItemService {
 
+  static final int MIN_RATE = 0;
+  static final int MAX_RATE = 9999;
+
+  /** Hardcoded catalog: defines item structure (ids, names, groups, combos) and default rates. */
   private static final List<Item> ITEMS = new ArrayList<>();
-  private static final List<ItemsGroup> GROUPED_ITEMS;
+
+  private static final Map<String, Item> ITEMS_BY_ID;
+
+  private final ItemRateRepository itemRateRepository;
 
   static {
     ITEMS.add(new Item("blazerOrCoat", "Blazer/Coat", 3200, ItemGroup.COAT, ItemType.COAT));
@@ -113,15 +126,60 @@ public class ItemService {
         new Item("accessories", "Accessories", 1, ItemGroup.MISCELLANEOUS, ItemType.ACCESSORIES));
     ITEMS.add(new Item("others", "Others", 0, ItemGroup.MISCELLANEOUS, ItemType.OTHERS));
 
-    Map<String, List<Item>> groupNameToItemsMap =
-        ITEMS.stream().collect(Collectors.groupingBy(Item::getGroupName));
-    GROUPED_ITEMS =
-        ItemGroup.ORDERED_GROUPS.stream()
-            .map(groupName -> new ItemsGroup(groupName, groupNameToItemsMap.get(groupName)))
-            .toList();
+    ITEMS_BY_ID = ITEMS.stream().collect(Collectors.toMap(Item::getId, Function.identity()));
   }
 
+  /** Returns the catalog grouped by category, with any persisted rate overrides applied. */
   public List<ItemsGroup> getGroupedItems() {
-    return GROUPED_ITEMS;
+    Map<String, Integer> rateOverrides = loadRateOverrides();
+    Map<String, List<Item>> groupNameToItemsMap =
+        ITEMS.stream()
+            .map(item -> withRate(item, rateOverrides.getOrDefault(item.getId(), item.getRate())))
+            .collect(Collectors.groupingBy(Item::getGroupName));
+    return ItemGroup.ORDERED_GROUPS.stream()
+        .map(groupName -> new ItemsGroup(groupName, groupNameToItemsMap.get(groupName)))
+        .toList();
+  }
+
+  /**
+   * Persists rate overrides for the given items. {@code rates} maps item id to new rate. Validates
+   * that ids are known and rates are within [MIN_RATE, MAX_RATE].
+   */
+  public void updateRates(Map<String, Integer> rates) {
+    if (rates == null || rates.isEmpty()) {
+      throw new IllegalArgumentException("rates must be non-null and non-empty");
+    }
+    List<ItemRate> toSave = new ArrayList<>();
+    for (Map.Entry<String, Integer> entry : rates.entrySet()) {
+      String itemId = entry.getKey();
+      Integer rate = entry.getValue();
+      if (!ITEMS_BY_ID.containsKey(itemId)) {
+        throw new IllegalArgumentException("Unknown item id: " + itemId);
+      }
+      if (rate == null || rate < MIN_RATE || rate > MAX_RATE) {
+        throw new IllegalArgumentException(
+            "Rate for '" + itemId + "' must be between " + MIN_RATE + " and " + MAX_RATE);
+      }
+      toSave.add(new ItemRate(itemId, rate));
+    }
+    itemRateRepository.saveAll(toSave);
+  }
+
+  private Map<String, Integer> loadRateOverrides() {
+    Map<String, Integer> overrides = new HashMap<>();
+    try {
+      itemRateRepository
+          .findAll()
+          .forEach(itemRate -> overrides.put(itemRate.getId(), itemRate.getRate()));
+    } catch (Exception e) {
+      // Keep the catalog working exactly as before (hardcoded default rates) even if the rate
+      // override store is unavailable. getGroupedItems() must never fail because of overrides.
+      log.warn("Failed to load item rate overrides; falling back to default rates", e);
+    }
+    return overrides;
+  }
+
+  private static Item withRate(Item item, int rate) {
+    return item.toBuilder().rate(rate).build();
   }
 }

--- a/src/main/java/com/harvi/tailor/item/RateController.java
+++ b/src/main/java/com/harvi/tailor/item/RateController.java
@@ -1,0 +1,22 @@
+package com.harvi.tailor.item;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("rates")
+@CrossOrigin
+@RequiredArgsConstructor
+public class RateController {
+
+  private final ItemService itemService;
+
+  @PostMapping
+  public void updateRates(@RequestBody RatesUpdateRequest request) {
+    itemService.updateRates(request.rates());
+  }
+}

--- a/src/main/java/com/harvi/tailor/item/RatesUpdateRequest.java
+++ b/src/main/java/com/harvi/tailor/item/RatesUpdateRequest.java
@@ -1,0 +1,6 @@
+package com.harvi.tailor.item;
+
+import java.util.Map;
+
+/** Map of item id to new rate. */
+public record RatesUpdateRequest(Map<String, Integer> rates) {}

--- a/start-datastore-emulator.sh
+++ b/start-datastore-emulator.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Start Google Cloud Datastore emulator for local development.
+# Run this in a separate terminal BEFORE starting the Spring Boot app from IntelliJ.
+#
+# Uses ./db_data if present (existing local order data); otherwise starts empty.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+PROJECT_ID="gujrati-tailors-backend"
+HOST_PORT="localhost:8081"
+DATA_DIR="${SCRIPT_DIR}/db_data"
+
+ARGS=(
+  beta emulators datastore start
+  --project="${PROJECT_ID}"
+  --host-port="${HOST_PORT}"
+)
+
+if [[ -d "${DATA_DIR}" ]]; then
+  echo "Using persisted emulator data: ${DATA_DIR}"
+  ARGS+=(--data-dir="${DATA_DIR}")
+else
+  echo "No ${DATA_DIR} found; starting with empty datastore."
+fi
+
+echo "Starting Datastore emulator on ${HOST_PORT} (project: ${PROJECT_ID})"
+echo "Leave this terminal running. Then run GujratiTailorsApplication from IntelliJ."
+echo ""
+
+exec gcloud "${ARGS[@]}"


### PR DESCRIPTION
## Summary
- Add runtime rate overrides stored in Cloud Datastore (`itemRate` kind), overlaying the hardcoded item catalog in `ItemService`.
- Expose `POST /rates` with body `{ "rates": { "itemId": rate, ... } }` for shop-owner rate updates.
- Return `Cache-Control: no-store` on `GET /items/groupedItems` so clients always see current rates.
- Map validation errors (`IllegalArgumentException`) to HTTP 400.

## Notes
- No Datastore index or schema setup required — `itemRate` kind is created on first save; `findAll()` needs no composite index.
- Backward compatible: empty overrides fall back to hardcoded defaults; existing orders keep snapshotted rates.
- Deploy backend before UI.

## Test plan
- [x] `mvn verify` passes (fmt check + tests)
- [x] Update rate via API/UI; new orders use updated rate
- [x] Existing order line items keep original snapshotted rate
- [x] Re-add item on order edit shows updated rate
- [ ] Deploy to GAE and smoke-test `POST /rates` + `GET /items/groupedItems` in production

Made with [Cursor](https://cursor.com)